### PR TITLE
Fix checksum mismatch for 0.7.1 and backwards checksum mismatch message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:22.04
 
 # Set environment variables
 ENV CONTAINER_VERSION=1.1 \
-    ELDEWRITO_VERSION=0.7.0 \
-    MTNDEW_CHECKSUM=e6f02924bb0e9bdfe690b7973fce00e9 \
+    ELDEWRITO_VERSION=0.7.1 \
+    MTNDEW_CHECKSUM=f1d6c49381ac1ec572f0f405e4cd406b \
     DISPLAY=:1 \
     WINEPREFIX="/wine" \
     DEBIAN_FRONTEND=noninteractive \

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+k#!/bin/sh
 
 NC='\033[0m'
 GREEN='\033[0;32m'
@@ -23,8 +23,8 @@ if [ -z "${SKIP_CHECKSUM_CHECK}" ]; then
         echo "${RED}Checksum mismatch! Make sure you are using a valid copy of the game.${NC}"
         echo "${RED}This container only supports ElDewrito ${ELDEWRITO_VERSION}.${NC}"
 
-        echo "Expected ${checksum}"
-        echo "Got ${MTNDEW_CHECKSUM}"
+        echo "Expected ${MTNDEW_CHECKSUM}"
+        echo "Got ${checksum}"
 
         sleep 2
         exit 10


### PR DESCRIPTION
The md5sum in the current image is for 0.7 and errors out when using the latest version of ElDewrito (0.7.1). This is now fixed as well as the checksum mismatch message showing the wrong md5sum for the got and expected sums.