### PR TITLE
Fix typo in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-k#!/bin/sh
+#!/bin/sh
 
 NC='\033[0m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
Didn't realize there was a k before `#!/bin/sh`, not sure how that happened but it fucks the entire script. Should be fixed now.